### PR TITLE
Fix SPINE Discovery Messages with spaces not being sent to the frontend

### DIFF
--- a/app/hems.go
+++ b/app/hems.go
@@ -371,8 +371,11 @@ func (c *Cem) printFormat(msgType, format string, args ...interface{}) {
 // filter out UseCase and DetailedDiscovery
 func (c *Cem) filterSpineLogs(msg string) {
 	parts := strings.Split(msg, " ")
+	if len(parts) < 3 {
+		return
+	}
 
-	if parts[0] != "Recv:" && len(parts) < 3 {
+	if parts[0] != "Recv:" {
 		return
 	}
 

--- a/app/hems.go
+++ b/app/hems.go
@@ -371,11 +371,8 @@ func (c *Cem) printFormat(msgType, format string, args ...interface{}) {
 // filter out UseCase and DetailedDiscovery
 func (c *Cem) filterSpineLogs(msg string) {
 	parts := strings.Split(msg, " ")
-	if len(parts) != 3 {
-		return
-	}
 
-	if parts[0] != "Recv:" {
+	if parts[0] != "Recv:" && len(parts) < 3 {
 		return
 	}
 
@@ -394,11 +391,11 @@ func (c *Cem) filterSpineLogs(msg string) {
 	if len(msgService.Ski) == 0 {
 		return
 	}
-
+	payload := strings.Join(parts[2:], " ")
 	// discovery data
 	if strings.Contains(msg, "{\"payload\":[{\"cmd\":[[{\"nodeManagementDetailedDiscoveryData\":") &&
 		!strings.Contains(msg, "{\"nodeManagementDetailedDiscoveryData\":[]") {
-		c.discoveryData[ski] = parts[2]
+		c.discoveryData[ski] = payload
 		c.broadcastServicesList()
 		return
 	}
@@ -406,7 +403,7 @@ func (c *Cem) filterSpineLogs(msg string) {
 	// usecase data
 	if strings.Contains(msg, "{\"payload\":[{\"cmd\":[[{\"nodeManagementUseCaseData\":") &&
 		!strings.Contains(msg, "{\"nodeManagementUseCaseData\":[]") {
-		c.usecaseData[ski] = parts[2]
+		c.usecaseData[ski] = payload
 		c.broadcastServicesList()
 		return
 	}


### PR DESCRIPTION
SPINE nodeManagementDetailedDiscoveryData messages may contain fields such as "description" or "label" with spaces in them e.g. https://github.com/enbility/devices/blob/main/elli/charger-connect-pro/discovery-data.json#L242 

The devices-app can receive these messages perfectly fine but fails to forward them to the frontend due to this:
```
func (c *Cem) filterSpineLogs(msg string) {
	parts := strings.Split(msg, " ")
	if len(parts) != 3 {
		return
	}
        ....
```
The frontend throws an error when attempting to parse the incomplete messages. 
